### PR TITLE
Add more DB configuration options

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -20,9 +20,9 @@ class Database
             "username" =>  getenv('DB_USERNAME'),
             "password" =>  getenv('DB_PASSWORD'),
             // "timezone" =>  getenv('DB_TIMEZONE'),
-            "charset" =>  "utf8",
-            "collation" =>  "utf8_general_ci",
-            "prefix" =>  ""
+            "charset" =>  getenv('DB_CHARSET') ? getenv('DB_CHARSET') : "utf8",
+            "collation" =>  getenv('DB_COLLATION') ? getenv('DB_COLLATION') : "utf8_general_ci",
+            "prefix" =>  getenv('DB_PREFIX') ? getenv('DB_PREFIX') : ""
         ]);
 
         $this->capsule->setEventDispatcher(new Dispatcher(new Container));

--- a/src/Database.php
+++ b/src/Database.php
@@ -20,9 +20,9 @@ class Database
             "username" =>  getenv('DB_USERNAME'),
             "password" =>  getenv('DB_PASSWORD'),
             // "timezone" =>  getenv('DB_TIMEZONE'),
-            "charset" =>  getenv('DB_CHARSET') ? getenv('DB_CHARSET') : "utf8",
-            "collation" =>  getenv('DB_COLLATION') ? getenv('DB_COLLATION') : "utf8_general_ci",
-            "prefix" =>  getenv('DB_PREFIX') ? getenv('DB_PREFIX') : ""
+            "charset" =>  getenv('DB_CHARSET') ?? "utf8",
+            "collation" =>  getenv('DB_COLLATION') ?? "utf8_general_ci",
+            "prefix" =>  getenv('DB_PREFIX') ?? ""
         ]);
 
         $this->capsule->setEventDispatcher(new Dispatcher(new Container));


### PR DESCRIPTION
Hi there! 

Currently, the `charset` and `collation` values for databases managed with Illuminate/Eloquent are set to fixed values. I added a way to changed them using environment variables. 

This should make Leaf more versatile since most databases use `utf8mb4` nowadays. 