### PR TITLE
Base path fix

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -621,7 +621,7 @@ class Router
      */
     public static function getBasePath()
     {
-        if (static::$serverBasePath === null) {
+        if (static::$serverBasePath === "") {
             static::$serverBasePath = implode('/', array_slice(explode('/', $_SERVER['SCRIPT_NAME']), 0, -1)) . '/';
         }
 


### PR DESCRIPTION
Version 2.5.0 broke base path by changing null to "", making the base path always '/'