### PR TITLE
Update Database.php

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -20,8 +20,8 @@ class Database
             "username" =>  getenv('DB_USERNAME'),
             "password" =>  getenv('DB_PASSWORD'),
             // "timezone" =>  getenv('DB_TIMEZONE'),
-            "charset" =>  getenv('DB_CHARSET') ?? "utf8",
-            "collation" =>  getenv('DB_COLLATION') ?? "utf8_general_ci",
+            "charset" =>  empty(getenv('DB_CHARSET')) ? "utf8" : getenv('DB_CHARSET'),
+            "collation" =>  empty(getenv('DB_COLLATION')) ? "utf8_general_ci" : getenv('DB_COLLATION'),
             "prefix" =>  getenv('DB_PREFIX') ?? ""
         ]);
 


### PR DESCRIPTION
Changed charset and collation to check for empty values instead of using the Null Coalescing Operator. The issue would arise when the values for the environment are not present resulting with empty string value for as getenv() will never return NULL value, making it impossible to ever reach the set default.