### PR TITLE
Fix error: Cannot use Container as array

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -165,7 +165,7 @@ class App extends Router
 
                 // Default log
                 $this->container->singleton('log', function ($c) {
-                    $log = new \Leaf\Log($c['logWriter']);
+                    $log = new \Leaf\Log($c->logWriter);
                     $log->enabled($this->config('log.enabled'));
                     $log->level($this->config('log.level'));
 


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description

An **object** of type Leaf\Helpers\Container is being **used as an array**
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Related Issue
- #139
- #141 
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->