### PR TITLE
V3.x dev

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,8 @@
 root = true
 
 [*]
-indent_style = tab
-indent_size = 4
+indent_style = space
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"leafs/http": "^2.1",
-		"leafs/router": "^0.1",
-		"leafs/anchor": "^1.2",
-		"leafs/exception": "^3.0"
+		"leafs/http": "*",
+		"leafs/router": "*",
+		"leafs/anchor": "*",
+		"leafs/exception": "*"
 	},
 	"require-dev": {
 		"pestphp/pest": "^1.21",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 	"prefer-stable": true,
 	"require": {
 		"leafs/http": "^2.1",
-		"leafs/router": "^0.1.7",
+		"leafs/router": "^0.1",
 		"leafs/anchor": "^1.2",
 		"leafs/exception": "^3.0"
 	},

--- a/src/App.php
+++ b/src/App.php
@@ -362,7 +362,7 @@ class App extends Router
      */
     public function root()
     {
-        return rtrim($_SERVER['DOCUMENT_ROOT'], '/') . rtrim($this->request->getRootUri(), '/') . '/';
+        return rtrim($_SERVER['DOCUMENT_ROOT'], '/') . rtrim($this->request->getScriptName(), '/') . '/';
     }
 
     /**

--- a/src/App.php
+++ b/src/App.php
@@ -17,399 +17,399 @@ namespace Leaf;
  */
 class App extends Router
 {
-    /**
-     * Leaf container instance
-     * @var \Leaf\Helpers\Container
-     */
-    protected $container;
+  /**
+   * Leaf container instance
+   * @var \Leaf\Helpers\Container
+   */
+  protected $container;
 
-    /**
-     * Callable to be invoked on application error
-     */
-    protected $errorHandler;
+  /**
+   * Callable to be invoked on application error
+   */
+  protected $errorHandler;
 
-    /********************************************************************************
-     * Instantiation and Configuration
-     *******************************************************************************/
+  /********************************************************************************
+   * Instantiation and Configuration
+   *******************************************************************************/
 
-    /**
-     * Constructor
-     * @param array $userSettings Associative array of application settings
-     */
-    public function __construct(array $userSettings = [])
-    {
-        if (class_exists('\Leaf\BareUI')) {
-            View::attach(\Leaf\BareUI::class, 'template');
-        }
-
-        $this->setupErrorHandler();
-        $this->container = new \Leaf\Helpers\Container();
-        $this->loadConfig($userSettings);
-
-        if (class_exists('\Leaf\Anchor\CSRF')) {
-            if (!Anchor\CSRF::token()) {
-                Anchor\CSRF::init();
-            }
-
-            if (!Anchor\CSRF::verify()) {
-                $csrfError = Anchor\CSRF::errors()['token'];
-                Http\Response::status(400);
-                echo Exception\General::csrf($csrfError);
-                exit();
-            }
-        }
+  /**
+   * Constructor
+   * @param array $userSettings Associative array of application settings
+   */
+  public function __construct(array $userSettings = [])
+  {
+    if (class_exists('\Leaf\BareUI')) {
+      View::attach(\Leaf\BareUI::class, 'template');
     }
 
-    protected function loadConfig(array $userSettings = [])
-    {
-        if (count($userSettings) > 0) {
-            Config::set($userSettings);
-        }
+    $this->setupErrorHandler();
+    $this->container = new \Leaf\Helpers\Container();
+    $this->loadConfig($userSettings);
 
-        $this->setupDefaultContainer();
-        $this->loadViewEngines();
-    }
+    if (class_exists('\Leaf\Anchor\CSRF')) {
+      if (!Anchor\CSRF::token()) {
+        Anchor\CSRF::init();
+      }
 
-    protected function setupErrorHandler()
-    {
-        if ($this->config('debug') === true) {
-            $debugConfig = [E_ALL, 1];
-            $this->errorHandler = (new \Leaf\Exception\Run());
-            $this->errorHandler->register();
-        } else {
-            $debugConfig = [0, 0];
-            $this->setErrorHandler(['\Leaf\Exception\General', 'defaultError'], true);
-        }
-
-        error_reporting($debugConfig[0]);
-        ini_set('display_errors', (string) $debugConfig[1]);
-    }
-
-    /**
-     * Set a custom error screen.
-     *
-     * @param callable|array $handler The function to be executed
-     */
-    public function setErrorHandler($handler, bool $wrapper = true)
-    {
-        $errorHandler = $handler;
-
-        if ($this->errorHandler instanceof \Leaf\Exception\Run) {
-            $this->errorHandler->unregister();
-        }
-
-        if ($handler instanceof \Leaf\Exception\Handler\Handler) {
-            $this->errorHandler = new \Leaf\Exception\Run();
-            $this->errorHandler->pushHandler($handler)->register();
-        }
-
-        if ($wrapper) {
-            $errorHandler = function ($errno, $errstr = '', $errfile = '', $errline = '') use ($handler) {
-                $exception = Exception\General::toException($errno, $errstr, $errfile, $errline);
-                Http\Headers::resetStatus(500);
-                call_user_func_array($handler, [$exception]);
-                exit();
-            };
-        }
-
-        set_error_handler($errorHandler);
-    }
-
-    /**
-     * This method adds a method to the global leaf instance
-     * Register a method and use it globally on the Leaf Object
-     */
-    public function register($name, $value)
-    {
-        $this->container->singleton($name, $value);
-    }
-
-    public function loadViewEngines()
-    {
-        $views = View::$engines;
-
-        if (count($views) > 0) {
-            foreach ($views as $key => $value) {
-                $this->container->singleton($key, function () use ($value) {
-                    return $value;
-                });
-            }
-        }
-    }
-
-    private function setupDefaultContainer()
-    {
-        // Default request
-        $this->container->singleton('request', function () {
-            return new \Leaf\Http\Request();
-        });
-
-        // Default response
-        $this->container->singleton('response', function () {
-            return new \Leaf\Http\Response();
-        });
-
-        // Default headers
-        $this->container->singleton('headers', function () {
-            return new \Leaf\Http\Headers();
-        });
-
-        if ($this->config('log.enabled')) {
-            if (class_exists('Leaf\Log')) {
-                // Default log writer
-                $this->container->singleton('logWriter', function ($c) {
-                    $logWriter = Config::get('log.writer');
-
-                    $file = $this->config('log.dir') . $this->config('log.file');
-
-                    return is_object($logWriter) ? $logWriter : new \Leaf\LogWriter($file, $this->config('log.open') ?? true);
-                });
-
-                // Default log
-                $this->container->singleton('log', function ($c) {
-                    $log = new \Leaf\Log($c->logWriter);
-                    $log->enabled($this->config('log.enabled'));
-                    $log->level($this->config('log.level'));
-
-                    return $log;
-                });
-            }
-        }
-
-        // Default mode
-        $mode = $this->config('mode');
-
-        if (_env('APP_ENV')) {
-            $mode = _env('APP_ENV');
-        }
-
-        if (_env('LEAF_MODE')) {
-            $mode = _env('LEAF_MODE');
-        }
-
-        if (isset($_ENV['LEAF_MODE'])) {
-            $mode = $_ENV['LEAF_MODE'];
-        } else {
-            $envMode = getenv('LEAF_MODE');
-
-            if ($envMode !== false) {
-                $mode = $envMode;
-            }
-        }
-
-        Config::set([
-            'mode' => $mode,
-            'app' => [
-                'instance' => $this,
-                'container' => $this->container,
-            ],
-        ]);
-    }
-
-    public function __get($name)
-    {
-        return $this->container->get($name);
-    }
-
-    public function __set($name, $value)
-    {
-        $this->container->set($name, $value);
-    }
-
-    public function __isset($name)
-    {
-        return $this->container->has($name);
-    }
-
-    public function __unset($name)
-    {
-        $this->container->remove($name);
-    }
-
-    /**
-     * Configure Leaf Settings
-     *
-     * This method defines application settings and acts as a setter and a getter.
-     *
-     * If only one argument is specified and that argument is a string, the value
-     * of the setting identified by the first argument will be returned, or NULL if
-     * that setting does not exist.
-     *
-     * If only one argument is specified and that argument is an associative array,
-     * the array will be merged into the existing application settings.
-     *
-     * If two arguments are provided, the first argument is the name of the setting
-     * to be created or updated, and the second argument is the setting value.
-     *
-     * @param  string|array $name  If a string, the name of the setting to set or retrieve. Else an associated array of setting names and values
-     * @param  mixed $value If name is a string, the value of the setting identified by $name
-     * @return mixed The value of a setting if only one argument is a string
-     */
-    public function config($name, $value = null)
-    {
-        if ($value === null && is_string($name)) {
-            return Config::get($name);
-        }
-
-        Config::set($name, $value);
-        $this->loadConfig();
-        $this->setupErrorHandler();
-    }
-
-    /**
-     * Swap out Leaf request instance
-     *
-     * @param mixed $class The new request class to attach
-     */
-    public function setRequestClass($class)
-    {
-        $this->container->singleton('request', function () {
-            return new \Leaf\Http\Request();
-        });
-    }
-
-    /**
-     * Swap out Leaf response instance
-     *
-     * @param mixed $class The new response class to attach
-     */
-    public function setResponseClass($class)
-    {
-        $this->container->singleton('response', function () use ($class) {
-            return new $class();
-        });
-    }
-
-    /********************************************************************************
-     * Logging
-     *******************************************************************************/
-
-    /**
-     * Get application log
-     *
-     * @return \Leaf\Log|null|void
-     */
-    public function logger()
-    {
-        if (!$this->log) {
-            trigger_error('You need to enable logging to use this feature! Set log.enabled to true and install the logger module');
-        }
-
-        return $this->log;
-    }
-
-    /********************************************************************************
-     * Application Accessors
-     *******************************************************************************/
-
-    /**
-     * Get the Request Headers
-     * @return \Leaf\Http\Headers
-     */
-    public function headers()
-    {
-        return $this->headers;
-    }
-
-    /**
-     * Get the Request object
-     * @return \Leaf\Http\Request
-     */
-    public function request()
-    {
-        return $this->request;
-    }
-
-    /**
-     * Get the Response object
-     * @return \Leaf\Http\Response
-     */
-    public function response()
-    {
-        return $this->response;
-    }
-
-    /**
-     * Create mode-specific code
-     *
-     * @param string $mode The mode to run code in
-     * @param callable $callback The code to run in selected mode.
-     */
-    public static function script($mode, $callback)
-    {
-        static::hook('router.before', function () use ($mode, $callback) {
-            $appMode = Config::get('mode') ?? 'development';
-
-            if ($mode === $appMode) {
-                return $callback();
-            }
-        });
-    }
-
-    /********************************************************************************
-     * Helper Methods
-     *******************************************************************************/
-
-    /**
-     * Get the absolute path to this Leaf application's root directory
-     *
-     * This method returns the absolute path to the Leaf application's
-     * directory. If the Leaf application is installed in a public-accessible
-     * sub-directory, the sub-directory path will be included. This method
-     * will always return an absolute path WITH a trailing slash.
-     *
-     * @return string
-     */
-    public function root()
-    {
-        return rtrim($_SERVER['DOCUMENT_ROOT'], '/') . rtrim($this->request->getScriptName(), '/') . '/';
-    }
-
-    /**
-     * Clean current output buffer
-     */
-    protected function cleanBuffer()
-    {
-        if (ob_get_level() !== 0) {
-            ob_clean();
-        }
-    }
-
-    /**
-     * Halt
-     *
-     * Stop the application and immediately send the response with a
-     * specific status and body to the HTTP client. This may send any
-     * type of response: info, success, redirect, client error, or server error.
-     *
-     * @param int $status The HTTP response status
-     * @param string $message The HTTP response body
-     */
-    public static function halt($status, $message = '')
-    {
-        if (ob_get_level() !== 0) {
-            ob_clean();
-        }
-
-        Http\Headers::status($status);
-        Http\Response::markup($message);
-
+      if (!Anchor\CSRF::verify()) {
+        $csrfError = Anchor\CSRF::errors()['token'];
+        Http\Response::status(400);
+        echo Exception\General::csrf($csrfError);
         exit();
+      }
+    }
+  }
+
+  protected function loadConfig(array $userSettings = [])
+  {
+    if (count($userSettings) > 0) {
+      Config::set($userSettings);
     }
 
-    /**
-     * Evade CORS errors
-     *
-     * Cors handler
-     *
-     * @param $options Config for cors
-     */
-    public function cors($options = [])
-    {
-        if (class_exists('Leaf\Http\Cors')) {
-            Http\Cors::config($options);
-        } else {
-            trigger_error('Cors module not found! Run `composer require leafs/cors` to install the CORS module. This is required to configure CORS.');
-        }
+    $this->setupDefaultContainer();
+    $this->loadViewEngines();
+  }
+
+  protected function setupErrorHandler()
+  {
+    if ($this->config('debug') === true) {
+      $debugConfig = [E_ALL, 1];
+      $this->errorHandler = (new \Leaf\Exception\Run());
+      $this->errorHandler->register();
+    } else {
+      $debugConfig = [0, 0];
+      $this->setErrorHandler(['\Leaf\Exception\General', 'defaultError'], true);
     }
+
+    error_reporting($debugConfig[0]);
+    ini_set('display_errors', (string) $debugConfig[1]);
+  }
+
+  /**
+   * Set a custom error screen.
+   *
+   * @param callable|array $handler The function to be executed
+   */
+  public function setErrorHandler($handler, bool $wrapper = true)
+  {
+    $errorHandler = $handler;
+
+    if ($this->errorHandler instanceof \Leaf\Exception\Run) {
+      $this->errorHandler->unregister();
+    }
+
+    if ($handler instanceof \Leaf\Exception\Handler\Handler) {
+      $this->errorHandler = new \Leaf\Exception\Run();
+      $this->errorHandler->pushHandler($handler)->register();
+    }
+
+    if ($wrapper) {
+      $errorHandler = function ($errno, $errstr = '', $errfile = '', $errline = '') use ($handler) {
+        $exception = Exception\General::toException($errno, $errstr, $errfile, $errline);
+        Http\Headers::resetStatus(500);
+        call_user_func_array($handler, [$exception]);
+        exit();
+      };
+    }
+
+    set_error_handler($errorHandler);
+  }
+
+  /**
+   * This method adds a method to the global leaf instance
+   * Register a method and use it globally on the Leaf Object
+   */
+  public function register($name, $value)
+  {
+    $this->container->singleton($name, $value);
+  }
+
+  public function loadViewEngines()
+  {
+    $views = View::$engines;
+
+    if (count($views) > 0) {
+      foreach ($views as $key => $value) {
+        $this->container->singleton($key, function () use ($value) {
+          return $value;
+        });
+      }
+    }
+  }
+
+  private function setupDefaultContainer()
+  {
+    // Default request
+    $this->container->singleton('request', function () {
+      return new \Leaf\Http\Request();
+    });
+
+    // Default response
+    $this->container->singleton('response', function () {
+      return new \Leaf\Http\Response();
+    });
+
+    // Default headers
+    $this->container->singleton('headers', function () {
+      return new \Leaf\Http\Headers();
+    });
+
+    if ($this->config('log.enabled')) {
+      if (class_exists('Leaf\Log')) {
+        // Default log writer
+        $this->container->singleton('logWriter', function ($c) {
+          $logWriter = Config::get('log.writer');
+
+          $file = $this->config('log.dir') . $this->config('log.file');
+
+          return is_object($logWriter) ? $logWriter : new \Leaf\LogWriter($file, $this->config('log.open') ?? true);
+        });
+
+        // Default log
+        $this->container->singleton('log', function ($c) {
+          $log = new \Leaf\Log($c->logWriter);
+          $log->enabled($this->config('log.enabled'));
+          $log->level($this->config('log.level'));
+
+          return $log;
+        });
+      }
+    }
+
+    // Default mode
+    $mode = $this->config('mode');
+
+    if (_env('APP_ENV')) {
+      $mode = _env('APP_ENV');
+    }
+
+    if (_env('LEAF_MODE')) {
+      $mode = _env('LEAF_MODE');
+    }
+
+    if (isset($_ENV['LEAF_MODE'])) {
+      $mode = $_ENV['LEAF_MODE'];
+    } else {
+      $envMode = getenv('LEAF_MODE');
+
+      if ($envMode !== false) {
+        $mode = $envMode;
+      }
+    }
+
+    Config::set([
+      'mode' => $mode,
+      'app' => [
+        'instance' => $this,
+        'container' => $this->container,
+      ],
+    ]);
+  }
+
+  public function __get($name)
+  {
+    return $this->container->get($name);
+  }
+
+  public function __set($name, $value)
+  {
+    $this->container->set($name, $value);
+  }
+
+  public function __isset($name)
+  {
+    return $this->container->has($name);
+  }
+
+  public function __unset($name)
+  {
+    $this->container->remove($name);
+  }
+
+  /**
+   * Configure Leaf Settings
+   *
+   * This method defines application settings and acts as a setter and a getter.
+   *
+   * If only one argument is specified and that argument is a string, the value
+   * of the setting identified by the first argument will be returned, or NULL if
+   * that setting does not exist.
+   *
+   * If only one argument is specified and that argument is an associative array,
+   * the array will be merged into the existing application settings.
+   *
+   * If two arguments are provided, the first argument is the name of the setting
+   * to be created or updated, and the second argument is the setting value.
+   *
+   * @param  string|array $name  If a string, the name of the setting to set or retrieve. Else an associated array of setting names and values
+   * @param  mixed $value If name is a string, the value of the setting identified by $name
+   * @return mixed The value of a setting if only one argument is a string
+   */
+  public function config($name, $value = null)
+  {
+    if ($value === null && is_string($name)) {
+      return Config::get($name);
+    }
+
+    Config::set($name, $value);
+    $this->loadConfig();
+    $this->setupErrorHandler();
+  }
+
+  /**
+   * Swap out Leaf request instance
+   *
+   * @param mixed $class The new request class to attach
+   */
+  public function setRequestClass($class)
+  {
+    $this->container->singleton('request', function () {
+      return new \Leaf\Http\Request();
+    });
+  }
+
+  /**
+   * Swap out Leaf response instance
+   *
+   * @param mixed $class The new response class to attach
+   */
+  public function setResponseClass($class)
+  {
+    $this->container->singleton('response', function () use ($class) {
+      return new $class();
+    });
+  }
+
+  /********************************************************************************
+   * Logging
+   *******************************************************************************/
+
+  /**
+   * Get application log
+   *
+   * @return \Leaf\Log|null|void
+   */
+  public function logger()
+  {
+    if (!$this->log) {
+      trigger_error('You need to enable logging to use this feature! Set log.enabled to true and install the logger module');
+    }
+
+    return $this->log;
+  }
+
+  /********************************************************************************
+   * Application Accessors
+   *******************************************************************************/
+
+  /**
+   * Get the Request Headers
+   * @return \Leaf\Http\Headers
+   */
+  public function headers()
+  {
+    return $this->headers;
+  }
+
+  /**
+   * Get the Request object
+   * @return \Leaf\Http\Request
+   */
+  public function request()
+  {
+    return $this->request;
+  }
+
+  /**
+   * Get the Response object
+   * @return \Leaf\Http\Response
+   */
+  public function response()
+  {
+    return $this->response;
+  }
+
+  /**
+   * Create mode-specific code
+   *
+   * @param string $mode The mode to run code in
+   * @param callable $callback The code to run in selected mode.
+   */
+  public static function script($mode, $callback)
+  {
+    static::hook('router.before', function () use ($mode, $callback) {
+      $appMode = Config::get('mode') ?? 'development';
+
+      if ($mode === $appMode) {
+        return $callback();
+      }
+    });
+  }
+
+  /********************************************************************************
+   * Helper Methods
+   *******************************************************************************/
+
+  /**
+   * Get the absolute path to this Leaf application's root directory
+   *
+   * This method returns the absolute path to the Leaf application's
+   * directory. If the Leaf application is installed in a public-accessible
+   * sub-directory, the sub-directory path will be included. This method
+   * will always return an absolute path WITH a trailing slash.
+   *
+   * @return string
+   */
+  public function root()
+  {
+    return rtrim($_SERVER['DOCUMENT_ROOT'], '/') . rtrim($this->request->getScriptName(), '/') . '/';
+  }
+
+  /**
+   * Clean current output buffer
+   */
+  protected function cleanBuffer()
+  {
+    if (ob_get_level() !== 0) {
+      ob_clean();
+    }
+  }
+
+  /**
+   * Halt
+   *
+   * Stop the application and immediately send the response with a
+   * specific status and body to the HTTP client. This may send any
+   * type of response: info, success, redirect, client error, or server error.
+   *
+   * @param int $status The HTTP response status
+   * @param string $message The HTTP response body
+   */
+  public static function halt($status, $message = '')
+  {
+    if (ob_get_level() !== 0) {
+      ob_clean();
+    }
+
+    Http\Headers::status($status);
+    Http\Response::markup($message);
+
+    exit();
+  }
+
+  /**
+   * Evade CORS errors
+   *
+   * Cors handler
+   *
+   * @param $options Config for cors
+   */
+  public function cors($options = [])
+  {
+    if (class_exists('Leaf\Http\Cors')) {
+      Http\Cors::config($options);
+    } else {
+      trigger_error('Cors module not found! Run `composer require leafs/cors` to install the CORS module. This is required to configure CORS.');
+    }
+  }
 }

--- a/src/App.php
+++ b/src/App.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Leaf;
 

--- a/src/App.php
+++ b/src/App.php
@@ -106,7 +106,7 @@ class App extends Router
         if ($wrapper) {
             $errorHandler = function ($errno, $errstr = '', $errfile = '', $errline = '') use ($handler) {
                 $exception = Exception\General::toException($errno, $errstr, $errfile, $errline);
-                Http\Response::status(500);
+                Http\Headers::resetStatus(500);
                 call_user_func_array($handler, [$exception]);
                 exit();
             };

--- a/src/App.php
+++ b/src/App.php
@@ -263,8 +263,8 @@ class App extends Router
      */
     public function setRequestClass($class)
     {
-        $this->container->singleton('request', function () {
-            return new \Leaf\Http\Request();
+        $this->container->singleton('request', function () use ($class) {
+            return new $class();
         });
     }
 

--- a/src/App.php
+++ b/src/App.php
@@ -17,399 +17,399 @@ namespace Leaf;
  */
 class App extends Router
 {
-  /**
-   * Leaf container instance
-   * @var \Leaf\Helpers\Container
-   */
-  protected $container;
+    /**
+     * Leaf container instance
+     * @var \Leaf\Helpers\Container
+     */
+    protected $container;
 
-  /**
-   * Callable to be invoked on application error
-   */
-  protected $errorHandler;
+    /**
+     * Callable to be invoked on application error
+     */
+    protected $errorHandler;
 
-  /********************************************************************************
-   * Instantiation and Configuration
-   *******************************************************************************/
+    /********************************************************************************
+     * Instantiation and Configuration
+     *******************************************************************************/
 
-  /**
-   * Constructor
-   * @param array $userSettings Associative array of application settings
-   */
-  public function __construct(array $userSettings = [])
-  {
-    if (class_exists('\Leaf\BareUI')) {
-      View::attach(\Leaf\BareUI::class, 'template');
+    /**
+     * Constructor
+     * @param array $userSettings Associative array of application settings
+     */
+    public function __construct(array $userSettings = [])
+    {
+        if (class_exists('\Leaf\BareUI')) {
+            View::attach(\Leaf\BareUI::class, 'template');
+        }
+
+        $this->setupErrorHandler();
+        $this->container = new \Leaf\Helpers\Container();
+        $this->loadConfig($userSettings);
+
+        if (class_exists('\Leaf\Anchor\CSRF')) {
+            if (!Anchor\CSRF::token()) {
+                Anchor\CSRF::init();
+            }
+
+            if (!Anchor\CSRF::verify()) {
+                $csrfError = Anchor\CSRF::errors()['token'];
+                Http\Response::status(400);
+                echo Exception\General::csrf($csrfError);
+                exit();
+            }
+        }
     }
 
-    $this->setupErrorHandler();
-    $this->container = new \Leaf\Helpers\Container();
-    $this->loadConfig($userSettings);
+    protected function loadConfig(array $userSettings = [])
+    {
+        if (count($userSettings) > 0) {
+            Config::set($userSettings);
+        }
 
-    if (class_exists('\Leaf\Anchor\CSRF')) {
-      if (!Anchor\CSRF::token()) {
-        Anchor\CSRF::init();
-      }
+        $this->setupDefaultContainer();
+        $this->loadViewEngines();
+    }
 
-      if (!Anchor\CSRF::verify()) {
-        $csrfError = Anchor\CSRF::errors()['token'];
-        Http\Response::status(400);
-        echo Exception\General::csrf($csrfError);
+    protected function setupErrorHandler()
+    {
+        if ($this->config('debug') === true) {
+            $debugConfig = [E_ALL, 1];
+            $this->errorHandler = (new \Leaf\Exception\Run());
+            $this->errorHandler->register();
+        } else {
+            $debugConfig = [0, 0];
+            $this->setErrorHandler(['\Leaf\Exception\General', 'defaultError'], true);
+        }
+
+        error_reporting($debugConfig[0]);
+        ini_set('display_errors', (string) $debugConfig[1]);
+    }
+
+    /**
+     * Set a custom error screen.
+     *
+     * @param callable|array $handler The function to be executed
+     */
+    public function setErrorHandler($handler, bool $wrapper = true)
+    {
+        $errorHandler = $handler;
+
+        if ($this->errorHandler instanceof \Leaf\Exception\Run) {
+            $this->errorHandler->unregister();
+        }
+
+        if ($handler instanceof \Leaf\Exception\Handler\Handler) {
+            $this->errorHandler = new \Leaf\Exception\Run();
+            $this->errorHandler->pushHandler($handler)->register();
+        }
+
+        if ($wrapper) {
+            $errorHandler = function ($errno, $errstr = '', $errfile = '', $errline = '') use ($handler) {
+                $exception = Exception\General::toException($errno, $errstr, $errfile, $errline);
+                Http\Headers::resetStatus(500);
+                call_user_func_array($handler, [$exception]);
+                exit();
+            };
+        }
+
+        set_error_handler($errorHandler);
+    }
+
+    /**
+     * This method adds a method to the global leaf instance
+     * Register a method and use it globally on the Leaf Object
+     */
+    public function register($name, $value)
+    {
+        $this->container->singleton($name, $value);
+    }
+
+    public function loadViewEngines()
+    {
+        $views = View::$engines;
+
+        if (count($views) > 0) {
+            foreach ($views as $key => $value) {
+                $this->container->singleton($key, function () use ($value) {
+                    return $value;
+                });
+            }
+        }
+    }
+
+    private function setupDefaultContainer()
+    {
+        // Default request
+        $this->container->singleton('request', function () {
+            return new \Leaf\Http\Request();
+        });
+
+        // Default response
+        $this->container->singleton('response', function () {
+            return new \Leaf\Http\Response();
+        });
+
+        // Default headers
+        $this->container->singleton('headers', function () {
+            return new \Leaf\Http\Headers();
+        });
+
+        if ($this->config('log.enabled')) {
+            if (class_exists('Leaf\Log')) {
+                // Default log writer
+                $this->container->singleton('logWriter', function ($c) {
+                    $logWriter = Config::get('log.writer');
+
+                    $file = $this->config('log.dir') . $this->config('log.file');
+
+                    return is_object($logWriter) ? $logWriter : new \Leaf\LogWriter($file, $this->config('log.open') ?? true);
+                });
+
+                // Default log
+                $this->container->singleton('log', function ($c) {
+                    $log = new \Leaf\Log($c->logWriter);
+                    $log->enabled($this->config('log.enabled'));
+                    $log->level($this->config('log.level'));
+
+                    return $log;
+                });
+            }
+        }
+
+        // Default mode
+        $mode = $this->config('mode');
+
+        if (_env('APP_ENV')) {
+            $mode = _env('APP_ENV');
+        }
+
+        if (_env('LEAF_MODE')) {
+            $mode = _env('LEAF_MODE');
+        }
+
+        if (isset($_ENV['LEAF_MODE'])) {
+            $mode = $_ENV['LEAF_MODE'];
+        } else {
+            $envMode = getenv('LEAF_MODE');
+
+            if ($envMode !== false) {
+                $mode = $envMode;
+            }
+        }
+
+        Config::set([
+          'mode' => $mode,
+          'app' => [
+            'instance' => $this,
+            'container' => $this->container,
+          ],
+        ]);
+    }
+
+    public function __get($name)
+    {
+        return $this->container->get($name);
+    }
+
+    public function __set($name, $value)
+    {
+        $this->container->set($name, $value);
+    }
+
+    public function __isset($name)
+    {
+        return $this->container->has($name);
+    }
+
+    public function __unset($name)
+    {
+        $this->container->remove($name);
+    }
+
+    /**
+     * Configure Leaf Settings
+     *
+     * This method defines application settings and acts as a setter and a getter.
+     *
+     * If only one argument is specified and that argument is a string, the value
+     * of the setting identified by the first argument will be returned, or NULL if
+     * that setting does not exist.
+     *
+     * If only one argument is specified and that argument is an associative array,
+     * the array will be merged into the existing application settings.
+     *
+     * If two arguments are provided, the first argument is the name of the setting
+     * to be created or updated, and the second argument is the setting value.
+     *
+     * @param  string|array $name  If a string, the name of the setting to set or retrieve. Else an associated array of setting names and values
+     * @param  mixed $value If name is a string, the value of the setting identified by $name
+     * @return mixed The value of a setting if only one argument is a string
+     */
+    public function config($name, $value = null)
+    {
+        if ($value === null && is_string($name)) {
+            return Config::get($name);
+        }
+
+        Config::set($name, $value);
+        $this->loadConfig();
+        $this->setupErrorHandler();
+    }
+
+    /**
+     * Swap out Leaf request instance
+     *
+     * @param mixed $class The new request class to attach
+     */
+    public function setRequestClass($class)
+    {
+        $this->container->singleton('request', function () {
+            return new \Leaf\Http\Request();
+        });
+    }
+
+    /**
+     * Swap out Leaf response instance
+     *
+     * @param mixed $class The new response class to attach
+     */
+    public function setResponseClass($class)
+    {
+        $this->container->singleton('response', function () use ($class) {
+            return new $class();
+        });
+    }
+
+    /********************************************************************************
+     * Logging
+     *******************************************************************************/
+
+    /**
+     * Get application log
+     *
+     * @return \Leaf\Log|null|void
+     */
+    public function logger()
+    {
+        if (!$this->log) {
+            trigger_error('You need to enable logging to use this feature! Set log.enabled to true and install the logger module');
+        }
+
+        return $this->log;
+    }
+
+    /********************************************************************************
+     * Application Accessors
+     *******************************************************************************/
+
+    /**
+     * Get the Request Headers
+     * @return \Leaf\Http\Headers
+     */
+    public function headers()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Get the Request object
+     * @return \Leaf\Http\Request
+     */
+    public function request()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Get the Response object
+     * @return \Leaf\Http\Response
+     */
+    public function response()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Create mode-specific code
+     *
+     * @param string $mode The mode to run code in
+     * @param callable $callback The code to run in selected mode.
+     */
+    public static function script($mode, $callback)
+    {
+        static::hook('router.before', function () use ($mode, $callback) {
+            $appMode = Config::get('mode') ?? 'development';
+
+            if ($mode === $appMode) {
+                return $callback();
+            }
+        });
+    }
+
+    /********************************************************************************
+     * Helper Methods
+     *******************************************************************************/
+
+    /**
+     * Get the absolute path to this Leaf application's root directory
+     *
+     * This method returns the absolute path to the Leaf application's
+     * directory. If the Leaf application is installed in a public-accessible
+     * sub-directory, the sub-directory path will be included. This method
+     * will always return an absolute path WITH a trailing slash.
+     *
+     * @return string
+     */
+    public function root()
+    {
+        return rtrim($_SERVER['DOCUMENT_ROOT'], '/') . rtrim($this->request->getScriptName(), '/') . '/';
+    }
+
+    /**
+     * Clean current output buffer
+     */
+    protected function cleanBuffer()
+    {
+        if (ob_get_level() !== 0) {
+            ob_clean();
+        }
+    }
+
+    /**
+     * Halt
+     *
+     * Stop the application and immediately send the response with a
+     * specific status and body to the HTTP client. This may send any
+     * type of response: info, success, redirect, client error, or server error.
+     *
+     * @param int $status The HTTP response status
+     * @param string $message The HTTP response body
+     */
+    public static function halt($status, $message = '')
+    {
+        if (ob_get_level() !== 0) {
+            ob_clean();
+        }
+
+        Http\Headers::status($status);
+        Http\Response::markup($message);
+
         exit();
-      }
-    }
-  }
-
-  protected function loadConfig(array $userSettings = [])
-  {
-    if (count($userSettings) > 0) {
-      Config::set($userSettings);
     }
 
-    $this->setupDefaultContainer();
-    $this->loadViewEngines();
-  }
-
-  protected function setupErrorHandler()
-  {
-    if ($this->config('debug') === true) {
-      $debugConfig = [E_ALL, 1];
-      $this->errorHandler = (new \Leaf\Exception\Run());
-      $this->errorHandler->register();
-    } else {
-      $debugConfig = [0, 0];
-      $this->setErrorHandler(['\Leaf\Exception\General', 'defaultError'], true);
+    /**
+     * Evade CORS errors
+     *
+     * Cors handler
+     *
+     * @param $options Config for cors
+     */
+    public function cors($options = [])
+    {
+        if (class_exists('Leaf\Http\Cors')) {
+            Http\Cors::config($options);
+        } else {
+            trigger_error('Cors module not found! Run `composer require leafs/cors` to install the CORS module. This is required to configure CORS.');
+        }
     }
-
-    error_reporting($debugConfig[0]);
-    ini_set('display_errors', (string) $debugConfig[1]);
-  }
-
-  /**
-   * Set a custom error screen.
-   *
-   * @param callable|array $handler The function to be executed
-   */
-  public function setErrorHandler($handler, bool $wrapper = true)
-  {
-    $errorHandler = $handler;
-
-    if ($this->errorHandler instanceof \Leaf\Exception\Run) {
-      $this->errorHandler->unregister();
-    }
-
-    if ($handler instanceof \Leaf\Exception\Handler\Handler) {
-      $this->errorHandler = new \Leaf\Exception\Run();
-      $this->errorHandler->pushHandler($handler)->register();
-    }
-
-    if ($wrapper) {
-      $errorHandler = function ($errno, $errstr = '', $errfile = '', $errline = '') use ($handler) {
-        $exception = Exception\General::toException($errno, $errstr, $errfile, $errline);
-        Http\Headers::resetStatus(500);
-        call_user_func_array($handler, [$exception]);
-        exit();
-      };
-    }
-
-    set_error_handler($errorHandler);
-  }
-
-  /**
-   * This method adds a method to the global leaf instance
-   * Register a method and use it globally on the Leaf Object
-   */
-  public function register($name, $value)
-  {
-    $this->container->singleton($name, $value);
-  }
-
-  public function loadViewEngines()
-  {
-    $views = View::$engines;
-
-    if (count($views) > 0) {
-      foreach ($views as $key => $value) {
-        $this->container->singleton($key, function () use ($value) {
-          return $value;
-        });
-      }
-    }
-  }
-
-  private function setupDefaultContainer()
-  {
-    // Default request
-    $this->container->singleton('request', function () {
-      return new \Leaf\Http\Request();
-    });
-
-    // Default response
-    $this->container->singleton('response', function () {
-      return new \Leaf\Http\Response();
-    });
-
-    // Default headers
-    $this->container->singleton('headers', function () {
-      return new \Leaf\Http\Headers();
-    });
-
-    if ($this->config('log.enabled')) {
-      if (class_exists('Leaf\Log')) {
-        // Default log writer
-        $this->container->singleton('logWriter', function ($c) {
-          $logWriter = Config::get('log.writer');
-
-          $file = $this->config('log.dir') . $this->config('log.file');
-
-          return is_object($logWriter) ? $logWriter : new \Leaf\LogWriter($file, $this->config('log.open') ?? true);
-        });
-
-        // Default log
-        $this->container->singleton('log', function ($c) {
-          $log = new \Leaf\Log($c->logWriter);
-          $log->enabled($this->config('log.enabled'));
-          $log->level($this->config('log.level'));
-
-          return $log;
-        });
-      }
-    }
-
-    // Default mode
-    $mode = $this->config('mode');
-
-    if (_env('APP_ENV')) {
-      $mode = _env('APP_ENV');
-    }
-
-    if (_env('LEAF_MODE')) {
-      $mode = _env('LEAF_MODE');
-    }
-
-    if (isset($_ENV['LEAF_MODE'])) {
-      $mode = $_ENV['LEAF_MODE'];
-    } else {
-      $envMode = getenv('LEAF_MODE');
-
-      if ($envMode !== false) {
-        $mode = $envMode;
-      }
-    }
-
-    Config::set([
-      'mode' => $mode,
-      'app' => [
-        'instance' => $this,
-        'container' => $this->container,
-      ],
-    ]);
-  }
-
-  public function __get($name)
-  {
-    return $this->container->get($name);
-  }
-
-  public function __set($name, $value)
-  {
-    $this->container->set($name, $value);
-  }
-
-  public function __isset($name)
-  {
-    return $this->container->has($name);
-  }
-
-  public function __unset($name)
-  {
-    $this->container->remove($name);
-  }
-
-  /**
-   * Configure Leaf Settings
-   *
-   * This method defines application settings and acts as a setter and a getter.
-   *
-   * If only one argument is specified and that argument is a string, the value
-   * of the setting identified by the first argument will be returned, or NULL if
-   * that setting does not exist.
-   *
-   * If only one argument is specified and that argument is an associative array,
-   * the array will be merged into the existing application settings.
-   *
-   * If two arguments are provided, the first argument is the name of the setting
-   * to be created or updated, and the second argument is the setting value.
-   *
-   * @param  string|array $name  If a string, the name of the setting to set or retrieve. Else an associated array of setting names and values
-   * @param  mixed $value If name is a string, the value of the setting identified by $name
-   * @return mixed The value of a setting if only one argument is a string
-   */
-  public function config($name, $value = null)
-  {
-    if ($value === null && is_string($name)) {
-      return Config::get($name);
-    }
-
-    Config::set($name, $value);
-    $this->loadConfig();
-    $this->setupErrorHandler();
-  }
-
-  /**
-   * Swap out Leaf request instance
-   *
-   * @param mixed $class The new request class to attach
-   */
-  public function setRequestClass($class)
-  {
-    $this->container->singleton('request', function () {
-      return new \Leaf\Http\Request();
-    });
-  }
-
-  /**
-   * Swap out Leaf response instance
-   *
-   * @param mixed $class The new response class to attach
-   */
-  public function setResponseClass($class)
-  {
-    $this->container->singleton('response', function () use ($class) {
-      return new $class();
-    });
-  }
-
-  /********************************************************************************
-   * Logging
-   *******************************************************************************/
-
-  /**
-   * Get application log
-   *
-   * @return \Leaf\Log|null|void
-   */
-  public function logger()
-  {
-    if (!$this->log) {
-      trigger_error('You need to enable logging to use this feature! Set log.enabled to true and install the logger module');
-    }
-
-    return $this->log;
-  }
-
-  /********************************************************************************
-   * Application Accessors
-   *******************************************************************************/
-
-  /**
-   * Get the Request Headers
-   * @return \Leaf\Http\Headers
-   */
-  public function headers()
-  {
-    return $this->headers;
-  }
-
-  /**
-   * Get the Request object
-   * @return \Leaf\Http\Request
-   */
-  public function request()
-  {
-    return $this->request;
-  }
-
-  /**
-   * Get the Response object
-   * @return \Leaf\Http\Response
-   */
-  public function response()
-  {
-    return $this->response;
-  }
-
-  /**
-   * Create mode-specific code
-   *
-   * @param string $mode The mode to run code in
-   * @param callable $callback The code to run in selected mode.
-   */
-  public static function script($mode, $callback)
-  {
-    static::hook('router.before', function () use ($mode, $callback) {
-      $appMode = Config::get('mode') ?? 'development';
-
-      if ($mode === $appMode) {
-        return $callback();
-      }
-    });
-  }
-
-  /********************************************************************************
-   * Helper Methods
-   *******************************************************************************/
-
-  /**
-   * Get the absolute path to this Leaf application's root directory
-   *
-   * This method returns the absolute path to the Leaf application's
-   * directory. If the Leaf application is installed in a public-accessible
-   * sub-directory, the sub-directory path will be included. This method
-   * will always return an absolute path WITH a trailing slash.
-   *
-   * @return string
-   */
-  public function root()
-  {
-    return rtrim($_SERVER['DOCUMENT_ROOT'], '/') . rtrim($this->request->getScriptName(), '/') . '/';
-  }
-
-  /**
-   * Clean current output buffer
-   */
-  protected function cleanBuffer()
-  {
-    if (ob_get_level() !== 0) {
-      ob_clean();
-    }
-  }
-
-  /**
-   * Halt
-   *
-   * Stop the application and immediately send the response with a
-   * specific status and body to the HTTP client. This may send any
-   * type of response: info, success, redirect, client error, or server error.
-   *
-   * @param int $status The HTTP response status
-   * @param string $message The HTTP response body
-   */
-  public static function halt($status, $message = '')
-  {
-    if (ob_get_level() !== 0) {
-      ob_clean();
-    }
-
-    Http\Headers::status($status);
-    Http\Response::markup($message);
-
-    exit();
-  }
-
-  /**
-   * Evade CORS errors
-   *
-   * Cors handler
-   *
-   * @param $options Config for cors
-   */
-  public function cors($options = [])
-  {
-    if (class_exists('Leaf\Http\Cors')) {
-      Http\Cors::config($options);
-    } else {
-      trigger_error('Cors module not found! Run `composer require leafs/cors` to install the CORS module. This is required to configure CORS.');
-    }
-  }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -12,19 +12,19 @@ namespace Leaf;
 class Config
 {
     protected static $settings = [
-      'app' => ['down' => false, 'instance' => null],
-      'mode' => 'development',
-      'debug' => true,
-      'log' => [
-        'writer' => null,
-        'level' => null,
-        'enabled' => false,
-        'dir' => __DIR__ . '/../../../../storage/logs/',
-        'file' => 'log.txt',
-        'open' => true,
-      ],
-      'http' => ['version' => '1.1'],
-      'views' => ['path' => null, 'cachePath' => null],
+        'app' => ['down' => false, 'instance' => null],
+        'mode' => 'development',
+        'debug' => true,
+        'log' => [
+            'writer' => null,
+            'level' => null,
+            'enabled' => false,
+            'dir' => __DIR__ . '/../../../../storage/logs/',
+            'file' => 'log.txt',
+            'open' => true,
+        ],
+        'http' => ['version' => '1.1'],
+        'views' => ['path' => null, 'cachePath' => null],
     ];
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,80 +11,80 @@ namespace Leaf;
  */
 class Config
 {
-  protected static $settings = [
-    'app' => ['down' => false, 'instance' => null],
-    'mode' => 'development',
-    'debug' => true,
-    'log' => [
-      'writer' => null,
-      'level' => null,
-      'enabled' => false,
-      'dir' => __DIR__ . '/../../../../storage/logs/',
-      'file' => 'log.txt',
-      'open' => true,
-    ],
-    'http' => ['version' => '1.1'],
-    'views' => ['path' => null, 'cachePath' => null],
-  ];
+    protected static $settings = [
+      'app' => ['down' => false, 'instance' => null],
+      'mode' => 'development',
+      'debug' => true,
+      'log' => [
+        'writer' => null,
+        'level' => null,
+        'enabled' => false,
+        'dir' => __DIR__ . '/../../../../storage/logs/',
+        'file' => 'log.txt',
+        'open' => true,
+      ],
+      'http' => ['version' => '1.1'],
+      'views' => ['path' => null, 'cachePath' => null],
+    ];
 
-  /**
-   * Set configuration value(s)
-   *
-   * @param string|array $item The config(s) to set
-   * @param mixed $value The value for config. Ignored if $item is an array.
-   */
-  public static function set($item, $value = null)
-  {
-    if (is_string($item)) {
-      if (!strpos($item, '.')) {
-        static::$settings[$item] = $value;
-      } else {
-        static::$settings = array_merge(
-          static::$settings,
-          static::mapConfig($item, $value)
-        );
-      }
-    } else {
-      foreach ($item as $k => $v) {
-        static::set($k, $v);
-      }
-    }
-  }
-
-  /**
-   * Map nested config to their parents recursively
-   */
-  protected static function mapConfig(string $item, $value = null)
-  {
-    $config = explode('.', $item);
-
-    if (count($config) > 2) {
-      trigger_error('Nested config can\'t be more than 1 level deep');
+    /**
+     * Set configuration value(s)
+     *
+     * @param string|array $item The config(s) to set
+     * @param mixed $value The value for config. Ignored if $item is an array.
+     */
+    public static function set($item, $value = null)
+    {
+        if (is_string($item)) {
+            if (!strpos($item, '.')) {
+                static::$settings[$item] = $value;
+            } else {
+                static::$settings = array_merge(
+                    static::$settings,
+                    static::mapConfig($item, $value)
+                );
+            }
+        } else {
+            foreach ($item as $k => $v) {
+                static::set($k, $v);
+            }
+        }
     }
 
-    return [$config[0] => array_merge(
-      static::$settings[$config[0]] ?? [],
-      [$config[1] => $value]
-    )];
-  }
+    /**
+     * Map nested config to their parents recursively
+     */
+    protected static function mapConfig(string $item, $value = null)
+    {
+        $config = explode('.', $item);
 
-  /**
-   * Get configuration
-   *
-   * @param string|null $item The config to get. Returns all items if nothing is specified.
-   */
-  public static function get($item = null)
-  {
-    if ($item) {
-      $items = explode('.', $item);
+        if (count($config) > 2) {
+            trigger_error('Nested config can\'t be more than 1 level deep');
+        }
 
-      if (count($items) > 1) {
-        return static::$settings[$items[0]][$items[1]] ?? null;
-      }
-
-      return static::$settings[$item] ?? null;
+        return [$config[0] => array_merge(
+            static::$settings[$config[0]] ?? [],
+            [$config[1] => $value]
+        )];
     }
 
-    return static::$settings;
-  }
+    /**
+     * Get configuration
+     *
+     * @param string|null $item The config to get. Returns all items if nothing is specified.
+     */
+    public static function get($item = null)
+    {
+        if ($item) {
+            $items = explode('.', $item);
+
+            if (count($items) > 1) {
+                return static::$settings[$items[0]][$items[1]] ?? null;
+            }
+
+            return static::$settings[$item] ?? null;
+        }
+
+        return static::$settings;
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,80 +11,80 @@ namespace Leaf;
  */
 class Config
 {
-    protected static $settings = [
-        'app' => ['down' => false, 'instance' => null],
-        'mode' => 'development',
-        'debug' => true,
-        'log' => [
-            'writer' => null,
-            'level' => null,
-            'enabled' => false,
-            'dir' => __DIR__ . '/../../../../storage/logs/',
-            'file' => 'log.txt',
-            'open' => true,
-        ],
-        'http' => ['version' => '1.1'],
-        'views' => ['path' => null, 'cachePath' => null],
-    ];
+  protected static $settings = [
+    'app' => ['down' => false, 'instance' => null],
+    'mode' => 'development',
+    'debug' => true,
+    'log' => [
+      'writer' => null,
+      'level' => null,
+      'enabled' => false,
+      'dir' => __DIR__ . '/../../../../storage/logs/',
+      'file' => 'log.txt',
+      'open' => true,
+    ],
+    'http' => ['version' => '1.1'],
+    'views' => ['path' => null, 'cachePath' => null],
+  ];
 
-    /**
-     * Set configuration value(s)
-     *
-     * @param string|array $item The config(s) to set
-     * @param mixed $value The value for config. Ignored if $item is an array.
-     */
-    public static function set($item, $value = null)
-    {
-        if (is_string($item)) {
-            if (!strpos($item, '.')) {
-                static::$settings[$item] = $value;
-            } else {
-                static::$settings = array_merge(
-                    static::$settings,
-                    static::mapConfig($item, $value)
-                );
-            }
-        } else {
-            foreach ($item as $k => $v) {
-                static::set($k, $v);
-            }
-        }
+  /**
+   * Set configuration value(s)
+   *
+   * @param string|array $item The config(s) to set
+   * @param mixed $value The value for config. Ignored if $item is an array.
+   */
+  public static function set($item, $value = null)
+  {
+    if (is_string($item)) {
+      if (!strpos($item, '.')) {
+        static::$settings[$item] = $value;
+      } else {
+        static::$settings = array_merge(
+          static::$settings,
+          static::mapConfig($item, $value)
+        );
+      }
+    } else {
+      foreach ($item as $k => $v) {
+        static::set($k, $v);
+      }
+    }
+  }
+
+  /**
+   * Map nested config to their parents recursively
+   */
+  protected static function mapConfig(string $item, $value = null)
+  {
+    $config = explode('.', $item);
+
+    if (count($config) > 2) {
+      trigger_error('Nested config can\'t be more than 1 level deep');
     }
 
-    /**
-     * Map nested config to their parents recursively
-     */
-    protected static function mapConfig(string $item, $value = null)
-    {
-        $config = explode('.', $item);
+    return [$config[0] => array_merge(
+      static::$settings[$config[0]] ?? [],
+      [$config[1] => $value]
+    )];
+  }
 
-        if (count($config) > 2) {
-            trigger_error('Nested config can\'t be more than 1 level deep');
-        }
+  /**
+   * Get configuration
+   *
+   * @param string|null $item The config to get. Returns all items if nothing is specified.
+   */
+  public static function get($item = null)
+  {
+    if ($item) {
+      $items = explode('.', $item);
 
-        return [$config[0] => array_merge(
-            static::$settings[$config[0]] ?? [],
-            [$config[1] => $value]
-        )];
+      if (count($items) > 1) {
+        return static::$settings[$items[0]][$items[1]] ?? null;
+      }
+
+      return static::$settings[$item] ?? null;
     }
 
-    /**
-     * Get configuration
-     *
-     * @param string|null $item The config to get. Returns all items if nothing is specified.
-     */
-    public static function get($item = null)
-    {
-        if ($item) {
-            $items = explode('.', $item);
-
-            if (count($items) > 1) {
-                return static::$settings[$items[0]][$items[1]] ?? null;
-            }
-
-            return static::$settings[$item] ?? null;
-        }
-
-        return static::$settings;
-    }
+    return static::$settings;
+  }
 }

--- a/tests/app.test.php
+++ b/tests/app.test.php
@@ -29,29 +29,28 @@ test('app mode', function () {
 });
 
 test('set 404', function () {
-    app()->config('app.down', false);
+    app()->config('testKey.one', 'ooooo');
 
     $_SERVER['REQUEST_METHOD'] = 'POST';
     $_SERVER['REQUEST_URI'] = '/home';
 
     app()->set404(function () {
-        app()->config('app.down', true);
+        app()->config('testKey.one', true);
     });
 
     app()->run();
 
-    expect(app()->config('app.down'))->toBe(true);
+    expect(app()->config('testKey.one'))->toBe(true);
 });
 
 test('leaf middleware', function () {
-    $app = new Leaf\App();
-    app()->config('app.down', false);
+    app()->config('anotherKey', false);
 
     class AppMid extends \Leaf\Middleware
     {
         public function call()
         {
-            app()->config('app.down', true);
+            app()->config('anotherKey', true);
             $this->next();
         }
     }
@@ -64,7 +63,7 @@ test('leaf middleware', function () {
     });
     app()->run();
 
-    expect(app()->config('app.down'))->toBe(true);
+    expect(app()->config('anotherKey'))->toBe(true);
 });
 
 test('in-route middleware', function () {
@@ -72,17 +71,17 @@ test('in-route middleware', function () {
     $_SERVER['REQUEST_URI'] = '/';
 
     $app = new Leaf\App();
-    $app->config('app.down', false);
+    $app->config('useMiddleware', false);
 
     $m = function () use ($app) {
-        $app->config('app.down', true);
+        $app->config('useMiddleware', true);
     };
 
     $app->get('/', ['middleware' => $m, function () {
     }]);
     $app->run();
 
-    expect($app->config('app.down'))->toBe(true);
+    expect($app->config('useMiddleware'))->toBe(true);
 });
 
 test('before route middleware', function () {

--- a/tests/config.test.php
+++ b/tests/config.test.php
@@ -21,23 +21,23 @@ test('centralized config after init', function () {
 });
 
 test('nested config', function () {
-    app()->config('app.key', '2');
+    app()->config('randomKey.number', '2');
 
-    $appConfig = app()->config('app');
+    $randomKey = app()->config('randomKey');
 
-    expect(isset($appConfig['key']))->toBeTrue();
-    expect($appConfig['key'])->toBe('2');
-    expect(app()->config('app.key'))->toBe('2');
+    expect(isset($randomKey['number']))->toBeTrue();
+    expect($randomKey['number'])->toBe('2');
+    expect(app()->config('randomKey.number'))->toBe('2');
 });
 
 test('nested config (array)', function () {
-    app()->config(['app.key' => '2']);
+    app()->config(['nestedKey.number' => '2']);
 
-    $appConfig = app()->config('app');
+    $nestedKey = app()->config('nestedKey');
 
-    expect(isset($appConfig['key']))->toBeTrue();
-    expect($appConfig['key'])->toBe('2');
-    expect(app()->config('app.key'))->toBe('2');
+    expect(isset($nestedKey['number']))->toBeTrue();
+    expect($nestedKey['number'])->toBe('2');
+    expect(app()->config('nestedKey.number'))->toBe('2');
 });
 
 test('nested config (custom group)', function () {


### PR DESCRIPTION
## Description

This PR contains fixes for styling, tests, renamed methods, debug config, inheriting the request class, and env. It also adds functionality to refresh config after an update in the leaf application. This means you can safely set config after Leaf has been initialized and Leaf would take care of the rest. This PR also removes version constraints on some modules so the user can update without Composer shouting in the console.

## Related Issue

[#152](https://github.com/leafsphp/leaf/issues/152)