### PR TITLE
Unify namespace

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -38,12 +38,12 @@ class App extends Router
     public function __construct(array $userSettings = [])
     {
         $this->setupErrorHandler();
-        $this->container = new \Leaf\Helpers\Container();
+        $this->container = new Helpers\Container();
         $this->loadConfig($userSettings);
 
         if (!empty($this->config('scripts'))) {
             foreach ($this->config('scripts') as $script) {
-                call_user_func($script, $this, \Leaf\Config::get());
+                call_user_func($script, $this, Config::get());
             }
 
             $this->loadConfig();
@@ -62,7 +62,7 @@ class App extends Router
 
     protected function setupErrorHandler()
     {
-        $this->errorHandler = (new \Leaf\Exception\Run());
+        $this->errorHandler = (new Exception\Run());
         $this->errorHandler->register();
     }
 
@@ -73,11 +73,11 @@ class App extends Router
     public function setErrorHandler($handler)
     {
         if (Anchor::toBool($this->config('debug')) === false) {
-            if ($this->errorHandler instanceof \Leaf\Exception\Run) {
+            if ($this->errorHandler instanceof Exception\Run) {
                 $this->errorHandler->unregister();
             }
 
-            $this->errorHandler = new \Leaf\Exception\Run();
+            $this->errorHandler = new Exception\Run();
             $this
                 ->errorHandler
                 ->pushHandler($handler)
@@ -185,7 +185,7 @@ class App extends Router
      */
     public function attach(callable $code)
     {
-        call_user_func($code, $this, \Leaf\Config::get());
+        call_user_func($code, $this, Config::get());
         $this->loadConfig();
         $this->setupErrorHandler();
     }

--- a/src/App.php
+++ b/src/App.php
@@ -271,27 +271,24 @@ class App extends Router
 
     /**
      * Get the Request Headers
-     * @return \Leaf\Http\Headers
      */
-    public function headers()
+    public function headers(): Http\Headers
     {
         return $this->headers;
     }
 
     /**
      * Get the Request object
-     * @return \Leaf\Http\Request
      */
-    public function request()
+    public function request(): Http\Request
     {
         return $this->request;
     }
 
     /**
      * Get the Response object
-     * @return \Leaf\Http\Response
      */
-    public function response()
+    public function response(): Http\Response
     {
         return $this->response;
     }

--- a/src/App.php
+++ b/src/App.php
@@ -114,15 +114,15 @@ class App extends Router
     private function setupDefaultContainer()
     {
         $this->container->singleton('request', function () {
-            return new \Leaf\Http\Request();
+            return new Http\Request();
         });
 
         $this->container->singleton('response', function () {
-            return new \Leaf\Http\Response();
+            return new Http\Response();
         });
 
         $this->container->singleton('headers', function () {
-            return new \Leaf\Http\Headers();
+            return new Http\Headers();
         });
 
         Config::set('mode', _env('APP_ENV', $this->config('mode')));

--- a/src/App.php
+++ b/src/App.php
@@ -19,14 +19,13 @@ class App extends Router
 {
     /**
      * Leaf container instance
-     * @var \Leaf\Helpers\Container
      */
-    protected $container;
+    protected Helpers\Container $container;
 
     /**
      * Callable to be invoked on application error
      */
-    protected $errorHandler;
+    protected Exception\Run $errorHandler;
 
     /********************************************************************************
      * Instantiation and Configuration


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description
As the App Class, use namespace Leaf, any function or class call will be relative to that namespace.

Actually exist a mix of fully qualified namespaces and normal.
Now all use normal qualified.

Also added type hint to the properties.
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

![image](https://github.com/leafsphp/leaf/assets/249085/d015c12b-b37b-44c6-a077-a20b756630bf)
