### PR TITLE
Add minimal PHP version in composer.json

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
+        extensions: json, zip
         tools: composer:v2
         coverage: xdebug
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
+		"php": "^7.2|^8.0",
 		"leafs/http": "*",
 		"leafs/router": "*",
 		"leafs/anchor": "*",

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,8 @@
 	"prefer-stable": true,
 	"require": {
 		"php": "^7.2|^8.0",
+		"ext-json": "*",
+		"ext-zip": "*",
 		"leafs/http": "*",
 		"leafs/router": "*",
 		"leafs/anchor": "*",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"php": "^7.2|^8.0",
+		"php": "^7.4|^8.0",
 		"ext-json": "*",
 		"ext-zip": "*",
 		"leafs/http": "*",


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description
Require minimum PHP version.
Now install with any version, but later it will not work.

And inform to any developer only reading the `composer.json`.


Added also php extensions json and zip, as the documentation explain that are needed.
We can remove the need for extensions, but need to be added to the modules that need it.
But in reallity the App load automatically modules than need it.
<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->



<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->