### PR TITLE
use arrow function

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -374,9 +374,7 @@ class App extends Router
     {
         if (\class_exists('Leaf\Eien\Server') && Config::get('eien.enabled')) {
             server()
-                ->wrap(function () use ($callback) {
-                    parent::run($callback);
-                })
+                ->wrap(fn() => parent::run($callback))
                 ->listen();
         } else {
             return parent::run($callback);


### PR DESCRIPTION
Use arrow function (fn) instead classic function syntax with closure (function, use). 
Pros:  shorter, better readability.
Cons: none (I guess).