### PR TITLE
Remove `getenv()` which is not thread safe

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -29,7 +29,7 @@ if (!function_exists('_env')) {
      */
     function _env($key, $default = null)
     {
-        $env = array_merge(getenv() ?? [], $_ENV ?? []);
+        $env = array_merge($_ENV ?? []);
 
         return $env[$key] ??= $default;
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe below

## Description

`putenv()` and `getenv()` functions are not thread-safe. You can read the warning directly from `vlucas/phpdotenv` here: [vlucas/phpdotenv#putenv-and-getenv](https://github.com/vlucas/phpdotenv#putenv-and-getenv)

These functions can easily break the core functionality of web sites even under a little stress. In the pull request, I have removed `getenv()` from `_env()`. I ran the tests and all have been passed. You can check it from the screenshot below:
 
![image](https://github.com/user-attachments/assets/71815afc-f019-4eb1-8e2b-3e0e49bc122c)

However, some Leaf modules (such as `db`) still use `getenv()` to get the environment variables. This pull request will affect them and break their functionality. Before merging, `getenv` should be replaced with `_env` in these modules. 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
