### PR TITLE
Update tests.yml add PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["ubuntu-latest","macos-latest","windows-latest"]
-        php: ["8.3","8.2","8.1","8.0","7.4"]
+        php: ["8.4","8.3","8.2","8.1","8.0","7.4"]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Actually show deprecated warnings

Released 21 Nov 2024.
https://www.php.net/releases/8.4/en.php

`leaf: 2024/11/27 13:43:04 [error] 30#30: *1 FastCGI sent in stderr: "PHP message: PHP Deprecated:  Leaf\Exception\Run::__construct(): Implicitly marking parameter $system as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/exception/src/Exception/Run.php on line 70; PHP message: PHP Deprecated:  {closure:Leaf\Exception\Handler\PrettyPageHandler::addDataTableCallback():386}(): Implicitly marking parameter $inspector as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/exception/src/Exception/Handler/PrettyPageHandler.php on line 386; PHP message: PHP Deprecated:  Leaf\Exception\Util\TemplateHelper::render(): Implicitly marking parameter $additionalVariables as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/exception/src/Exception/Util/TemplateHelper.php on line 237; PHP message: PHP Deprecated:  Leaf\Http\Request::params(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/http/src/Request.php on line 237; PHP message: PHP Deprecated:  Leaf\Http\Request::getOrDefault(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/http/src/Request.php on line 253; PHP message: PHP Deprecated:  Leaf\Http\Request::cookies(): Implicitly marking parameter $key as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/http/src/Request.php on line 303; PHP message: PHP Deprecated:  Leaf\Http\Response::download(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/http/src/Response.php on line 189; PHP message: PHP Deprecated:  Leaf\Http\Response::withCookie(): Implicitly marking parameter $expire as nullable is deprecated, the explicit nullable type must be used instead in /leaf/vendor/leafs/http/src/Response.php on line 359;`
