### PR TITLE
Fix Leaf\Router base path validation to enforce exact match

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -707,7 +707,7 @@ class Router
 
         return '/' . trim($uri, '/');
     }
-    
+
     /**
      * Get route info of the current route
      *

--- a/src/Router.php
+++ b/src/Router.php
@@ -686,16 +686,28 @@ class Router
      */
     public static function getCurrentUri(): string
     {
-        // Get the current Request URI and remove rewrite base path from it (= allows one to run the router in a sub folder)
-        $uri = substr(rawurldecode($_SERVER['REQUEST_URI']), strlen(static::getBasePath()));
+        $basePath = static::getBasePath();
+        $requestUri = rawurldecode($_SERVER['REQUEST_URI']);
 
-        if (strstr($uri, '?')) {
-            $uri = substr($uri, 0, strpos($uri, '?'));
+        // Early exit If base path doesn't match
+        if (strncmp($requestUri, $basePath, strlen($basePath)) !== 0) {
+            if (!static::$notFoundHandler) {
+                static::$notFoundHandler = function () {
+                    \Leaf\Exception\General::default404();
+                };
+            }
+            static::invoke(static::$notFoundHandler);
+        }
+
+        // Get the current Request URI and remove rewrite base path from it (= allows one to run the router in a sub folder)
+        $uri = substr($requestUri, strlen($basePath)) ?: '/';
+        if (($queryPos = strpos($uri, '?')) !== false) {
+            $uri = substr($uri, 0, $queryPos);
         }
 
         return '/' . trim($uri, '/');
     }
-
+    
     /**
      * Get route info of the current route
      *


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## What kind of change does this PR introduce? (pls check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; how it makes building easier, etc.
	You can link to issues here.
-->
This PR fixes a bug in `Leaf\Router` where misspelled base paths (e.g., /portal/customarnama instead of /portal/customername set via setBasePath) were incorrectly processed, allowing routes to load instead of triggering a 404.


## Does this PR introduce a breaking change? (check one)

<!-- We prefer to avoid breaking changes. We will only accept PRs with breaking changes if they have been discussed in an issue first -->

- [ ] Yes
- [x] No

## Related Issue
Fixes #289 

<!-- If suggesting a new feature or change, please discuss it in an issue first -->

<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
